### PR TITLE
Change the comparison version

### DIFF
--- a/.github/workflows/dependency_javascript.yml
+++ b/.github/workflows/dependency_javascript.yml
@@ -36,7 +36,7 @@ jobs:
          # active: ${{ steps.get.outputs.active }}
          # maintenance: ${{ steps.get.outputs.maintenance }}
          lts: ${{ steps.get.outputs.lts }}
-         current: ${{ steps.get.outputs.current }}
+         current: ${{ steps.get.outputs.active }}
          # min: ${{ steps.get.outputs.min }}
 
 


### PR DESCRIPTION
Change the comparison value in the source query from `current` to `active`. This ensures that the latest version of Node.js is not used for comparison.