### PR TITLE
Pin CodeQL GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/tools_codeql.yml
+++ b/.github/workflows/tools_codeql.yml
@@ -59,7 +59,7 @@ jobs:
             # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       # Add any setup steps before running the `github/codeql-action/init` action.
       # This includes steps like installing compilers or runtimes (`actions/setup-node`
       # or others). This is typically only required for manual builds.
@@ -68,7 +68,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -96,6 +96,6 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
This PR updates the CodeQL workflow to pin all GitHub Actions to specific commit SHAs.

### What Changed
- Replaced version tags (e.g. `@v3`, `@v4`) with full commit SHA references.
- Ensured all CodeQL-related actions are pinned to immutable revisions.
- Standardized action versioning across the CodeQL workflow.